### PR TITLE
added errorStrategy

### DIFF
--- a/modules/unicycler.nf
+++ b/modules/unicycler.nf
@@ -1,6 +1,7 @@
 process unicycler {
 
     tag { sample_id + ' / ' + assembly_mode }
+    errorStrategy 'ignore'
 
     publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}_unicycler_${assembly_mode}.{fa,gfa,log}", mode: 'copy'
 


### PR DESCRIPTION
- I pulled the latest changes from 'main' (that included checkm2) and added 'errorStrategy' ignore to unicycler.nf to prevent the pipeline from failing when a particular sample failed at the assembly step. 